### PR TITLE
imx8mp-nominal.dtsi: Fix boot issue with USB3.0

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-nominal.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx8mp-nominal.dtsi
@@ -2229,7 +2229,6 @@
 				interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL_HIGH>;
 				phys = <&usb3_phy0>, <&usb3_phy0>;
 				phy-names = "usb2-phy", "usb3-phy";
-				maximum-speed = "high-speed";
 				snps,gfladj-refclk-lpm-sel-quirk;
 				snps,parkmode-disable-ss-quirk;
 			};
@@ -2273,7 +2272,6 @@
 				interrupts = <GIC_SPI 41 IRQ_TYPE_LEVEL_HIGH>;
 				phys = <&usb3_phy1>, <&usb3_phy1>;
 				phy-names = "usb2-phy", "usb3-phy";
-				maximum-speed = "high-speed";
 				snps,gfladj-refclk-lpm-sel-quirk;
 				snps,parkmode-disable-ss-quirk;
 			};


### PR DESCRIPTION
The system was only abel to boot from USB2-sticks not USB3.0 or USB3.2.

imx8mp.dtsi does not have the line:
    maximum-speed = "high-speed";

And removing it also resolves the issue on simpad2p.