### PR TITLE
imx8mp-nominal*.dtsi: Remove gpu_reserved node

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-nominal-industrial.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx8mp-nominal-industrial.dtsi
@@ -232,11 +232,6 @@
 			linux,cma-default;
 		};
 
-		gpu_reserved: gpu_reserved@100000000 {
-			no-map;
-			reg = <0x1 0x00000000 0 0x10000000>;
-		};
-
 		dsp_reserved: dsp@92400000 {
 			reg = <0 0x92400000 0 0x1000000>;
 			no-map;
@@ -2463,7 +2458,6 @@
 		cores = <&gpu_3d>, <&ml_vipsi>, <&gpu_2d>;
 		reg = <0x0 0x40000000 0x0 0xC0000000>, <0x0 0x0 0x0 0x10000000>;
 		reg-names = "phys_baseaddr", "contiguous_mem";
-		memory-region=<&gpu_reserved>;
 		status = "disabled";
 
 		throttle,max_state = <1>;

--- a/arch/arm64/boot/dts/freescale/imx8mp-nominal.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx8mp-nominal.dtsi
@@ -232,11 +232,6 @@
 			linux,cma-default;
 		};
 
-		gpu_reserved: gpu_reserved@100000000 {
-			no-map;
-			reg = <0x1 0x00000000 0 0x10000000>;
-		};
-
 		dsp_reserved: dsp@92400000 {
 			reg = <0 0x92400000 0 0x1000000>;
 			no-map;
@@ -2460,7 +2455,6 @@
 		cores = <&gpu_3d>, <&ml_vipsi>, <&gpu_2d>;
 		reg = <0x0 0x40000000 0x0 0xC0000000>, <0x0 0x0 0x0 0x10000000>;
 		reg-names = "phys_baseaddr", "contiguous_mem";
-		memory-region=<&gpu_reserved>;
 		status = "disabled";
 
 		throttle,max_state = <1>;


### PR DESCRIPTION
The node causes memory corruption issues:

https://community.nxp.com/t5/i-MX-Processors/Boot-crashes-on-iMX8MP-QuadLite/m-p/1953731

The node was added for better performance on  systems with lots of memory (more than 2GB). We only have 2GB of memory, and the performance drop should not be minimal with removing this node.

The node was added in:
https://github.com/nxp-imx/linux-imx/commit/25a09185d85a38a8a11f2151b78f90af4dd830b6