### PR TITLE
arch/arm/.../simpad2-revC.dts: Set correct interrupts trigger

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/simpad2-revC.dts
+++ b/arch/arm/boot/dts/nxp/imx/simpad2-revC.dts
@@ -525,8 +525,8 @@
 		compatible = "eeti,egalax_ts";
 		reg = <0x4>;
 		interrupt-parent = <&gpio7>;
-		interrupts = <13 2>;
-		wakeup-gpios = <&gpio7 13 0>;
+		interrupts = <13 IRQ_TYPE_LEVEL_LOW>;
+		wakeup-gpios = <&gpio7 13 IRQ_TYPE_NONE>;
 		disable-suspend = <1>;
 		status = "okay";
 		};


### PR DESCRIPTION
Trigger low used to be hardcoded see
https://github.com/torvalds/linux/commit/1ffb0cd82477775000cff02d2577a17308af6bbb

    Input: egalax_ts - do not hardcode interrupt trigger
    Stop hard-coding interrupt trigger, instead rely on the platform code
    to do the right thing, according to DT or ACPI data.

    Link: https://lore.kernel.org/r/20220920042608.1865560-4-dmitry.torokhov@gmail.com
    Signed-off-by: Dmitry Torokhov <dmitry.torokhov@gmail.com>

With the change in 1ffb0cd8 and without setting IRQ_TYPE_LEVEL_LOW the touch sceen on simpad plus acts erratically. Setting it to IRQ_TYPE_LEVEL_LOW makes it act smoothly again.