### PR TITLE
imx-pcm1681: Fix problem with swapped audio channels

### DIFF
--- a/sound/soc/fsl/imx-pcm1681.c
+++ b/sound/soc/fsl/imx-pcm1681.c
@@ -72,7 +72,8 @@ static const struct snd_soc_dapm_route audio_map_1681[] = {
 
 };
 
-static int imx_pcm1681_hw_param(struct snd_pcm_substream *substream, struct snd_pcm_hw_params *params)
+static int imx_pcm1681_hw_param(struct snd_pcm_substream *substream,
+					struct snd_pcm_hw_params *params)
 {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
@@ -84,8 +85,23 @@ static int imx_pcm1681_hw_param(struct snd_pcm_substream *substream, struct snd_
 	int slotw = 32;
 	u32 width = snd_pcm_format_width(params_format(params));
 	unsigned int clock_freq = 0;
+	u32 codec_dai_format = SND_SOC_DAIFMT_LEFT_J | SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_CBS_CFS;
+
+	ret = snd_soc_dai_set_fmt(codec_dai, codec_dai_format);
+	if (ret) {
+		dev_err(rtd->dev, "failed to set codec dai fmt: %d\n", ret);
+		return ret;
+	}
+	ret = snd_soc_dai_set_fmt(cpu_dai, codec_dai_format);
+	if (ret) {
+		dev_err(rtd->dev, "failed to set cpu dai fmt: %d\n", ret);
+		return ret;
+	}
+
 	switch (ch) {
 	case 2:
+	case 4:
+	case 6:
 		switch (sample_format) {
 		case SNDRV_PCM_FORMAT_S16_LE:
 			clock_freq = sample_rate * 32;
@@ -99,37 +115,35 @@ static int imx_pcm1681_hw_param(struct snd_pcm_substream *substream, struct snd_
 			return -EINVAL;
 			break;
 		}
-		snd_soc_dai_set_tdm_slot(cpu_dai, 0, 0, 0, 0);
-		snd_soc_dai_set_tdm_slot(codec_dai, 0, 0, 0, 0);
+
 		break;
 	case 8:
 		if (width >= 24) {
 			clock_freq = sample_rate * 256;
 		} else {
-			dev_err(rtd->dev, "%s: only S24_LE and S32_LE supported for TDM, was %d\n", __func__,
-				sample_format);
+			dev_err(rtd->dev, "%s: only S24_LE and S32_LE supported for TDM, was %d\n", __func__, sample_format);
 			return -EINVAL;
-		}
-		ret = snd_soc_dai_set_tdm_slot(cpu_dai, (1 << ch) - 1, 0x0, ch, slotw);
-		if (ret) {
-			dev_err(rtd->dev, "%s: failed to set cpu tdm fmt: %d\n", __func__, ret);
-			return ret;
-		}
-
-		ret = snd_soc_dai_set_tdm_slot(codec_dai, (1 << ch) - 1, 0x0, ch, slotw);
-		if (ret) {
-			dev_err(rtd->dev, "%s: failed to set codec tdm fmt: %d\n", __func__, ret);
-			return ret;
 		}
 		break;
 	default:
 
-		dev_err(rtd->dev, "%s: 2 or 8 channels must be used\n", __func__);
+		dev_err(rtd->dev, "%s: 2,4,6,8 channels must be used\n", __func__);
 		return -EINVAL;
 		break;
 	}
 
-	dev_dbg(rtd->dev, "%s: SAI clock is %d, rate is %d\n", __func__, clock_freq, sample_rate);
+	dev_dbg(rtd->dev, "%s: SAI clock is %d\n", __func__, clock_freq);
+	ret = snd_soc_dai_set_tdm_slot(cpu_dai, (1 << ch) - 1, 0x0, ch, slotw);
+	if (ret) {
+		dev_err(rtd->dev, "%s: failed to set cpu tdm fmt: %d\n", __func__, ret);
+		return ret;
+	}
+
+	ret = snd_soc_dai_set_tdm_slot(codec_dai, (1 << ch) - 1, 0x0, ch, slotw);
+	if (ret) {
+		dev_err(rtd->dev, "%s: failed to set codec tdm fmt: %d\n", __func__, ret);
+		return ret;
+	}
 
 	return 0;
 }
@@ -217,6 +231,7 @@ static int imx_pcm1681_probe(struct platform_device *pdev)
 	struct imx_pcm1681_data *data;
 	struct clk *codec_clk;
 	int ret;
+
 	const struct of_device_id *of_id = of_match_device(imx_pcm1681_dt_ids, &pdev->dev);
 	const struct board_variant *board_info = of_id ? (struct board_variant*)of_id->data : NULL;
 	if (!board_info) {

--- a/sound/soc/fsl/imx-pcm1681.c
+++ b/sound/soc/fsl/imx-pcm1681.c
@@ -86,13 +86,14 @@ static int imx_pcm1681_hw_param(struct snd_pcm_substream *substream,
 	u32 width = snd_pcm_format_width(params_format(params));
 	unsigned int clock_freq = 0;
 	u32 codec_dai_format = SND_SOC_DAIFMT_LEFT_J | SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_CBS_CFS;
+	u32 cpu_codec_dai_format = SND_SOC_DAIFMT_LEFT_J | SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_BP_FP;
 
 	ret = snd_soc_dai_set_fmt(codec_dai, codec_dai_format);
 	if (ret) {
 		dev_err(rtd->dev, "failed to set codec dai fmt: %d\n", ret);
 		return ret;
 	}
-	ret = snd_soc_dai_set_fmt(cpu_dai, codec_dai_format);
+	ret = snd_soc_dai_set_fmt(cpu_dai, cpu_codec_dai_format);
 	if (ret) {
 		dev_err(rtd->dev, "failed to set cpu dai fmt: %d\n", ret);
 		return ret;
@@ -191,15 +192,15 @@ static int imx_pcm1681_late_probe(struct snd_soc_card *card)
 	case CPUTYPE_IMX6:
 		dev_info(card->dev, "Set ESAI clk to %d\n", data->clk_frequency);
 		ret = snd_soc_dai_set_sysclk(cpu_dai, ESAI_HCKT_EXTAL,
-					     data->clk_frequency,
-					     SND_SOC_CLOCK_IN);
+						data->clk_frequency,
+						SND_SOC_CLOCK_IN);
 		break;
 
 	case CPUTYPE_IMX8:
 		dev_info(card->dev, "Set SAI mclk to %d\n", data->clk_frequency);
 		ret = snd_soc_dai_set_sysclk(cpu_dai, FSL_SAI_CLK_MAST1,
-					     data->clk_frequency,
-					     SND_SOC_CLOCK_OUT);
+						data->clk_frequency,
+						SND_SOC_CLOCK_OUT);
 		break;
 
 	default:
@@ -300,7 +301,7 @@ static int imx_pcm1681_probe(struct platform_device *pdev)
 
 	data->dai.ops = &imx_hifi_ops;
 	data->dai.dai_fmt = SND_SOC_DAIFMT_LEFT_J | SND_SOC_DAIFMT_NB_IF |
-			    SND_SOC_DAIFMT_CBS_CFS;
+				SND_SOC_DAIFMT_CBS_CFS;
 
 	data->card.dev = &pdev->dev;
 	ret = snd_soc_of_parse_card_name(&data->card, "model");


### PR DESCRIPTION
A problem with swapped audio channels has been observed. It was also
noticed the way imx_pcm1681_hw_param switched over the channels was
different in this version of the driver compared to the one used in
kirkstone. These changes makes the imx_pcm1681_hw_param function act
like in kirkstone.

Setting the cpu dai format to the same as codec dai format causes a
wirte error when playing to 8 channels

`snd_soc_dai_set_fmt(cpu_dai, codec_dai_format)` causes
`aplay: pcm_write:2178: write error: Input/output error`

Removing `snd_soc_dai_set_fmt(cpu_dai, codec_dai_format)` makes audio
play but rotated to the wrong channel, channel 1 gets played on channel
8 etc.

Since kernel 5.15 the commit below changes SND_SOC_DAIFMT_CBM_CFM to
SND_SOC_DAIFMT_BC_FC. Therefore we have to use the latter define rather
than the format. Doing that channel 8 gets output to channel 8.

    commit https://github.com/Laerdal/linux-fslc/commit/eb549779bbebbeaec4ddbe6e5279675435b745b1
    Author: Chancel Liu <chancel.liu@nxp.com>
    Date:   Thu Nov 16 14:46:00 2023 +0900

	LF-10571-1: ASoC: fsl_esai: Update set_fmt callback

	Use macro definition to directly tell CPU DAI drivers if they are clock
	provider or consumer.

	Signed-off-by: Chancel Liu <chancel.liu@nxp.com>
	Reviewed-by: Shengjiu Wang <shengjiu.wang@nxp.com>

Issue: https://github.com/akkodis-edge/simpad2-aen-bsp/issues/186