### PR TITLE
SP-9214: Fix microphone detection on SimPad PLUS 2

### DIFF
--- a/arch/arm64/boot/dts/freescale/dr-simpad2p-revC.dts
+++ b/arch/arm64/boot/dts/freescale/dr-simpad2p-revC.dts
@@ -185,8 +185,6 @@
 		audio-cpu = <&sai3>;
 		audio-codec = <&sgtl5000>;
 		SPKAMP-supply = <&reg_spk>;
-		hp-det-gpios = <&gpio4 27 GPIO_ACTIVE_LOW>;
-		mic-det-gpios = <&gpio5 5 GPIO_ACTIVE_LOW>;
 		audio-routing =
 			"Headphone Jack", "HP_OUT",
 			"AMIC", "Mic Bias",

--- a/arch/arm64/boot/dts/freescale/dr-simpad2p-revC.dts
+++ b/arch/arm64/boot/dts/freescale/dr-simpad2p-revC.dts
@@ -185,8 +185,8 @@
 		audio-cpu = <&sai3>;
 		audio-codec = <&sgtl5000>;
 		SPKAMP-supply = <&reg_spk>;
-		hp-det-gpios = <&gpio4 27 GPIO_ACTIVE_HIGH>;
-		mic-det-gpios = <&gpio5 5 GPIO_ACTIVE_HIGH>;
+		hp-det-gpios = <&gpio4 27 GPIO_ACTIVE_LOW>;
+		mic-det-gpios = <&gpio5 5 GPIO_ACTIVE_LOW>;
 		audio-routing =
 			"Headphone Jack", "HP_OUT",
 			"AMIC", "Mic Bias",

--- a/arch/arm64/boot/dts/freescale/dr-simpad2p-revC.dts
+++ b/arch/arm64/boot/dts/freescale/dr-simpad2p-revC.dts
@@ -185,6 +185,8 @@
 		audio-cpu = <&sai3>;
 		audio-codec = <&sgtl5000>;
 		SPKAMP-supply = <&reg_spk>;
+		hp-det-gpios = <&gpio4 27 GPIO_ACTIVE_HIGH>;
+		mic-det-gpios = <&gpio5 5 GPIO_ACTIVE_HIGH>;
 		audio-routing =
 			"Headphone Jack", "HP_OUT",
 			"AMIC", "Mic Bias",

--- a/sound/soc/fsl/lm-imx-sgtl5000.c
+++ b/sound/soc/fsl/lm-imx-sgtl5000.c
@@ -566,6 +566,11 @@ static int imx_sp2_audio_probe(struct platform_device *pdev)
 		goto cleanup;
 	}
 	if (data->board_info->iphone_jack && !IS_ERR_OR_NULL(data->iioc)) {
+		/* Force Mic Bias on for IIO current-based detection */
+		snd_soc_dapm_force_enable_pin(&data->card.dapm, "Mic Bias");
+		snd_soc_dapm_sync(&data->card.dapm);
+		dev_info(&pdev->dev, "Mic Bias forced on for IIO detection\n");
+
 		queue_delayed_work(system_power_efficient_wq, &data->mic_work,
 				   msecs_to_jiffies(500));
 	}


### PR DESCRIPTION
## Summary
Fixes microphone detection on SimPad PLUS 2 (IMX8) by forcing mic bias on for IIO current-based detection.

## Problem
SimPad2 was not detecting microphone/headset connections properly.

## Root Cause
- SimPad2 uses INA231 current sensor to detect jack type via mic bias current measurement
- SGTL5000 mic bias was not powered on, so the current sensor always read 0 regardless of jack state
- Without current flow, the IIO-based detection cannot differentiate between headset types

## Solution
**Machine Driver Changes** (`lm-imx-sgtl5000.c`):
- Force "Mic Bias" DAPM pin on when IIO detection is enabled (`iphone_jack = true`)
- This powers the SGTL5000 mic bias circuit, allowing current to flow
- Enables INA231 sensor to measure bias current accurately

## Detection Method
The INA231 sensor monitors mic bias current every 500ms to determine jack type:
- **500-6000 µA**: Headset (microphone + headphones) → Reports `SND_JACK_HEADSET`
- **≥6000 µA**: Headphones only → Reports `SND_JACK_HEADPHONE`
- **0-500 µA**: No jack connected

## Testing
After this fix, the system should:
- Detect headset insertion correctly via IIO current sensing
- Differentiate between headset (with mic) and headphones (no mic)
- Show proper jack state in ALSA controls

## Impact
- **SimPad2 (IMX8)**: Fixes microphone detection (uses IIO current sensing with `iphone_jack = true`)
- **Link Box 2 (IMX8)**: No impact (uses GPIO detection with `iphone_jack = false`, doesn't use IIO path)

## Technical Details
The fix targets the probe function where IIO detection is initialized. It forces the mic bias on immediately after card registration, ensuring the bias circuit is active when the periodic current measurement work queue starts.