### PR TITLE
SP-9369 Fix Linkbox PLUS memory size and CMA reservation

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/linkbox2-revD.dts
+++ b/arch/arm/boot/dts/nxp/imx/linkbox2-revD.dts
@@ -28,7 +28,13 @@
 	};
 
 	memory {
-		reg = <0x10000000 0x40000000>;
+		reg = <0x10000000 0x20000000>;
+	};
+
+	reserved-memory {
+		linux,cma {
+			size = <0x2000000>; /* 32 MiB - Linkbox has no display/IPU */
+		};
 	};
 
 	clocks {


### PR DESCRIPTION
## Summary
- Fix memory declaration from 1 GiB to 512 MiB to match actual Linkbox PLUS hardware
- Reduce CMA from 320 MiB (NXP imx6dl.dtsi default) to 32 MiB since the Linkbox has no display/IPU (both disabled)
- This fixes SPU install failure where the initramfs couldn't unpack due to ENOSPC — only ~135 MiB was available out of 512 MiB RAM

## Current state (before fix)
```
MemTotal:         501300 kB
MemFree:          101956 kB
MemAvailable:     254860 kB
CmaTotal:         327680 kB
CmaFree:           51008 kB
```
320 MiB CMA = 65% of all RAM reserved, with ~270 MiB unused.

## Expected state (after fix)
```
				Before	After
CmaTotal		320 MiB	32 MiB
MemFree			100 MiB	197 MiB
MemAvailable	249 MiB	347 MiB
```

## Test plan
- [ ] Build `sp-initrd-image` for `laerdal-simpad-system` and verify it boots on Linkbox PLUS
- [ ] Run SPU install on Linkbox PLUS and verify initramfs unpacks successfully
- [ ] Verify CMA pool is 32 MiB in kernel boot log (`Reserved memory: created CMA memory pool ... size 32 MiB`)
- [ ] Verify available memory is ~450+ MiB via `cat /proc/meminfo`
