### PR TITLE
SP-9384 Fix lm-imx-sgtl5000 optional GPIO handling and add I2C3 bus recovery

### DIFF
--- a/arch/arm64/boot/dts/freescale/dr-linkbox2p-revB.dts
+++ b/arch/arm64/boot/dts/freescale/dr-linkbox2p-revB.dts
@@ -600,8 +600,11 @@
 
 &i2c3 { /* CTP EXC80H32 , CTP EXC80H32	see exc3000.c */
 	clock-frequency = <100000>;
-	pinctrl-names = "default";
+	pinctrl-names = "default", "gpio";
 	pinctrl-0 = <&pinctrl_i2c3>;
+	pinctrl-1 = <&pinctrl_i2c3_gpio>;
+	scl-gpios = <&gpio5 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+	sda-gpios = <&gpio5 19 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 	status = "okay";
 
 	codec_pcm1681: pcm1681@4c {
@@ -822,6 +825,13 @@ BIT2:1 STRENGTH x1,x2,x4,x6
 		fsl,pins = <
 			MX8MP_IOMUXC_I2C3_SCL__I2C3_SCL		0x400001c2
 			MX8MP_IOMUXC_I2C3_SDA__I2C3_SDA		0x400001c2
+		>;
+	};
+
+	pinctrl_i2c3_gpio: i2c3gpiogrp {
+		fsl,pins = <
+			MX8MP_IOMUXC_I2C3_SCL__GPIO5_IO18	0x84
+			MX8MP_IOMUXC_I2C3_SDA__GPIO5_IO19	0x84
 		>;
 	};
 

--- a/arch/arm64/boot/dts/freescale/dr-linkbox2p-revC.dts
+++ b/arch/arm64/boot/dts/freescale/dr-linkbox2p-revC.dts
@@ -602,8 +602,11 @@
 
 &i2c3 { /* CTP EXC80H32 , CTP EXC80H32	see exc3000.c */
 	clock-frequency = <100000>;
-	pinctrl-names = "default";
+	pinctrl-names = "default", "gpio";
 	pinctrl-0 = <&pinctrl_i2c3>;
+	pinctrl-1 = <&pinctrl_i2c3_gpio>;
+	scl-gpios = <&gpio5 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+	sda-gpios = <&gpio5 19 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 	status = "okay";
 
 	codec_pcm1681: pcm1681@4c {
@@ -826,6 +829,13 @@ BIT2:1 STRENGTH x1,x2,x4,x6
 		fsl,pins = <
 			MX8MP_IOMUXC_I2C3_SCL__I2C3_SCL		0x400001c2
 			MX8MP_IOMUXC_I2C3_SDA__I2C3_SDA		0x400001c2
+		>;
+	};
+
+	pinctrl_i2c3_gpio: i2c3gpiogrp {
+		fsl,pins = <
+			MX8MP_IOMUXC_I2C3_SCL__GPIO5_IO18	0x84
+			MX8MP_IOMUXC_I2C3_SDA__GPIO5_IO19	0x84
 		>;
 	};
 

--- a/arch/arm64/boot/dts/freescale/dr-linkbox2p.dts
+++ b/arch/arm64/boot/dts/freescale/dr-linkbox2p.dts
@@ -664,8 +664,11 @@
 
 &i2c3 { /* CTP EXC80H32 , CTP EXC80H32	see exc3000.c */
 	clock-frequency = <100000>;
-	pinctrl-names = "default";
+	pinctrl-names = "default", "gpio";
 	pinctrl-0 = <&pinctrl_i2c3>;
+	pinctrl-1 = <&pinctrl_i2c3_gpio>;
+	scl-gpios = <&gpio5 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+	sda-gpios = <&gpio5 19 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 	status = "okay";
 
 	codec_pcm1681: pcm1681@4c {
@@ -872,6 +875,13 @@ BIT2:1 STRENGTH x1,x2,x4,x6
 		fsl,pins = <
 			MX8MP_IOMUXC_I2C3_SCL__I2C3_SCL		0x400001c2
 			MX8MP_IOMUXC_I2C3_SDA__I2C3_SDA		0x400001c2
+		>;
+	};
+
+	pinctrl_i2c3_gpio: i2c3gpiogrp {
+		fsl,pins = <
+			MX8MP_IOMUXC_I2C3_SCL__GPIO5_IO18	0x84
+			MX8MP_IOMUXC_I2C3_SDA__GPIO5_IO19	0x84
 		>;
 	};
 

--- a/sound/soc/fsl/lm-imx-sgtl5000.c
+++ b/sound/soc/fsl/lm-imx-sgtl5000.c
@@ -278,7 +278,7 @@ static int imx_sp2_hpjack_status_check(void *priv)
 {
 	struct imx_sp2_audio_data *data = priv;
 	int hp_status, ret=0;
-	if (IS_ERR(data->options.hp_gpio))
+	if (!data->options.hp_gpio)
 		return 0;
 	hp_status = gpiod_get_value(data->options.hp_gpio);
 
@@ -296,7 +296,7 @@ static int imx_sp2_micjack_status_check(void *priv)
 {
 	struct imx_sp2_audio_data *data = priv;
 	int mic_status, ret=0;
-	if (IS_ERR(data->options.mic_gpio))
+	if (!data->options.mic_gpio)
 		return 0;
 
 	mic_status = gpiod_get_value(data->options.mic_gpio);
@@ -322,7 +322,7 @@ static int imx_sp2_audio_jack_init(struct imx_sp2_audio_data *data)
 {
 	int ret;
 	dev_dbg(&data->pdev->dev, "jack init\n");
-	if (!IS_ERR(data->options.hp_gpio)) {
+	if (data->options.hp_gpio) {
 		imx_hp_jack_gpio[0].data = data;
 		imx_hp_jack_gpio[0].desc = data->options.hp_gpio;
 		imx_hp_jack_gpio[0].jack_status_check = imx_sp2_hpjack_status_check;
@@ -348,7 +348,7 @@ static int imx_sp2_audio_jack_init(struct imx_sp2_audio_data *data)
 		data->options.hp_attr = true;
 		data->options.mic_attr = true;
 	}
-	if (!IS_ERR(data->options.mic_gpio)) {
+	if (data->options.mic_gpio) {
 		imx_mic_jack_gpio[0].data = data;
 		imx_mic_jack_gpio[0].desc = data->options.mic_gpio;
 		imx_mic_jack_gpio[0].jack_status_check = imx_sp2_micjack_status_check;
@@ -493,14 +493,18 @@ static int imx_sp2_audio_probe(struct platform_device *pdev)
 	clk_put(codec_clk);
 	dev_info(&pdev->dev, "%s: codec clock is %d\n", __func__, data->clk_frequency);
 
-	data->options.hp_gpio = devm_gpiod_get(&pdev->dev, "hp-det", GPIOD_IN);
+	data->options.hp_gpio = devm_gpiod_get_optional(&pdev->dev, "hp-det", GPIOD_IN);
 	if (IS_ERR(data->options.hp_gpio)) {
-		dev_err(&pdev->dev, "%s: Failed to get 'hp-det-gpios' gpio", __func__);
+		ret = PTR_ERR(data->options.hp_gpio);
+		dev_err_probe(&pdev->dev, ret, "Failed to get 'hp-det-gpios' gpio\n");
+		goto cleanup;
 	}
 
-	data->options.mic_gpio = devm_gpiod_get(&pdev->dev, "mic-det", GPIOD_IN);
+	data->options.mic_gpio = devm_gpiod_get_optional(&pdev->dev, "mic-det", GPIOD_IN);
 	if (IS_ERR(data->options.mic_gpio)) {
-		dev_err(&pdev->dev, "%s: Failed to get 'mic-det-gpios' gpio", __func__);
+		ret = PTR_ERR(data->options.mic_gpio);
+		dev_err_probe(&pdev->dev, ret, "Failed to get 'mic-det-gpios' gpio\n");
+		goto cleanup;
 	}
 
 	INIT_DELAYED_WORK(&data->mic_work, imx_sp2_audio_read_bias_work);
@@ -574,7 +578,7 @@ static int imx_sp2_audio_probe(struct platform_device *pdev)
 		queue_delayed_work(system_power_efficient_wq, &data->mic_work,
 				   msecs_to_jiffies(500));
 	}
-	return 0;
+	ret = 0;
 cleanup:
 	if (cpu_pdev)
 		put_device(&cpu_pdev->dev);


### PR DESCRIPTION
## Summary

- **lm-imx-sgtl5000: fix optional GPIO handling** — Use `devm_gpiod_get_optional()` for hp-det and mic-det GPIOs since they are not present on all board revisions (revC uses IIO-based jack detection). Eliminates spurious error messages on every deferred probe retry, properly propagates `-EPROBE_DEFER`, and fixes a device tree node reference leak on the success path.
- **dr-linkbox2p: add I2C3 bus recovery** — Add GPIO-based I2C bus recovery configuration for I2C3 on all LinkBox2p device tree variants (revA, revB, revC/D). Without bus recovery, a warm reboot can leave the PCM1681 audio DAC holding SDA low from an interrupted transaction, causing all subsequent I2C transactions to NACK with `-ENXIO` until a full power cycle.

## Test plan

- [ ] Boot SimPad2 revC — verify no `hp-det-gpios`/`mic-det-gpios` error spam in dmesg
- [ ] Boot SimPad2 revA/B — verify headphone and microphone jack detection still works
- [ ] Warm reboot with PCM1681 active — verify I2C3 bus recovers without power cycle
